### PR TITLE
Updated SDK to v4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ MAINTAINER André Dumas
 RUN apt-get update && apt-get install -y \
     curl \
     python2.7-dev \
-    python-pip
+    python-pip \
+    libfreetype6
 
 # Install Pebble Tool
 ENV PEBBLE_TOOL_VERSION pebble-sdk-4.5-linux64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 MAINTAINER André Dumas
 
 # Instructions as per https://developer.pebble.com/sdk/install/linux/
@@ -7,14 +7,15 @@ MAINTAINER André Dumas
 RUN apt-get update && apt-get install -y \
     curl \
     python2.7-dev \
-    python-pip \
-    libfreetype6
+    python-pip
 
 # Install Pebble Tool
-ENV PEBBLE_TOOL_VERSION pebble-sdk-4.1.1-linux64
+ENV PEBBLE_TOOL_VERSION pebble-sdk-4.5-linux64
 ENV PEBBLE_PATH /root/pebble-dev
 ENV PEBBLE_HOME $PEBBLE_PATH/$PEBBLE_TOOL_VERSION
 ENV PATH $PEBBLE_HOME/bin:$PATH
+
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && apt-get install -y nodejs
 
 RUN mkdir -p $PEBBLE_PATH
 RUN curl -sSL https://s3.amazonaws.com/assets.getpebble.com/pebble-tool/$PEBBLE_TOOL_VERSION.tar.bz2 \
@@ -26,6 +27,8 @@ RUN /bin/bash -c " \
     pip install virtualenv \
     && virtualenv --no-site-packages .env \
     && source .env/bin/activate \
+    && pip uninstall six -y \
+    && pip install -I 'six==1.9.0' \
     && pip install -r requirements.txt \
     && deactivate \
     "
@@ -36,7 +39,7 @@ RUN /bin/bash -c " \
     "
 
 # Install Pebble SDK
-ENV PEBBLE_SDK_VERSION 3.9.2
+ENV PEBBLE_SDK_VERSION 4.3
 RUN yes | pebble sdk install $PEBBLE_SDK_VERSION
 
 VOLUME /pebble


### PR DESCRIPTION
This pull requests makes the following changes

- Updated the Ubuntu base image to 16.04 LTS
- Updated Pebble tool to v4.5
- Updated to Pebble SDK 4.3
- Added node.js since it's a dependency now

It manually removes and then downgrades `six` as a workaround for a bug somewhere in pip